### PR TITLE
docs: Fix a few typos

### DIFF
--- a/examples/apps/3Ddrawing/3Ddrawing.py
+++ b/examples/apps/3Ddrawing/3Ddrawing.py
@@ -18,7 +18,7 @@ set_brush(particle_fn, 10)
 class GL3DPerspective:
     """
     Handy Class for use with python 'with' statement.
-    on enter: sets the openGL pojection matrix to a standart perspective projection, enables, lighting, normalizing fo normals and depth test
+    on enter: sets the openGL projection matrix to a standart perspective projection, enables, lighting, normalizing fo normals and depth test
     on exit: restores matrices and states to what they were before
     """
     def __init__(self, angle=60.0, aspect=4.0/3.0, near=1.0, far=100.0):

--- a/examples/apps/mandelbrot/mandelbrot.py
+++ b/examples/apps/mandelbrot/mandelbrot.py
@@ -111,7 +111,7 @@ def pymt_plugin_activate(w, ctx):
     slider = MTSlider(orientation='horizontal', min=25, max=250, value=100, size=(w.width-20, 30), pos=(10,10))
 
     # attach the event handler to the slider
-    # uses curry to save the firt two arguments, since this is where we have the refernce to them
+    # uses curry to save the firt two arguments, since this is where we have the reference to them
     # and the on_value_changed event only provides on argument ('value')
     callback = curry(update_iterations, mbviewer, label)
     slider.push_handlers(on_value_change=callback)

--- a/pymt/cache.py
+++ b/pymt/cache.py
@@ -1,5 +1,5 @@
 '''
-Cache Manager: cache object and delete them automaticly
+Cache Manager: cache object and delete them automatically
 
 How to use the cache ::
     # register a new Cache
@@ -10,7 +10,7 @@ How to use the cache ::
     instance = MTLabel(label=label)
     Cache.append('mycache', label, instance)
 
-    # retreive the object later
+    # retrieve the object later
     instance = Cache.get('mycache', label)
 
 If the instance is NULL, the cache may have trash it, because you've
@@ -185,7 +185,7 @@ class Cache(object):
                 # time to draw. and the timeout is not adapted to the current
                 # framerate. So, increase the timeout by two.
                 # ie: if the timeout is 1 sec, and framerate go to 0.7, newly
-                # object added will be automaticly trashed.
+                # object added will be automatically trashed.
                 timeout *= 2
                 Cache._categories[category]['timeout'] = timeout
                 continue

--- a/pymt/core/text/__init__.py
+++ b/pymt/core/text/__init__.py
@@ -376,7 +376,7 @@ class LabelBase(BaseObject):
     def _set_label(self, label):
         if label == self._label:
             return
-        # try to automaticly decode unicode
+        # try to automatically decode unicode
         try:
             self._label = label.decode('utf8')
         except:

--- a/pymt/event.py
+++ b/pymt/event.py
@@ -325,7 +325,7 @@ class EventDispatcher(BaseObject):
     def dispatch_event(self, event_type, *args):
         '''Dispatch a single event to the attached handlers.
 
-        The event is propogated to all handlers from from the top of the stack
+        The event is propagated to all handlers from from the top of the stack
         until one returns `EVENT_HANDLED`.  This method should be used only by
         `EventDispatcher` implementors; applications should call
         the ``dispatch_events`` method.

--- a/pymt/input/touch.py
+++ b/pymt/input/touch.py
@@ -144,7 +144,7 @@ class Touch(object):
             self.dszpos = self.oszpos = self.sz
 
     def grab(self, class_instance, exclusive=False):
-        '''Grab a touch. You can grab a touch if you absolutly want to receive
+        '''Grab a touch. You can grab a touch if you absolutely want to receive
         on_touch_move() and on_touch_up(), even if the touch is not dispatched
         by your parent ::
 

--- a/pymt/tools/packaging/osx/build.py
+++ b/pymt/tools/packaging/osx/build.py
@@ -58,7 +58,7 @@ class OSXPortableBuild(Command):
             p = block_count*block_size*100.0/total_size
             print "\b\b\b\b\b\b\b\b\b", "%06.2f"%p +"%",
         print " Progress: 000.00%",
-        urlretrieve(self.deps_url, #location of binary dependencioes needed for portable pymt
+        urlretrieve(self.deps_url, #location of binary dependencies needed for portable pymt
                     os.path.join(self.build_dir,'deps.zip'), #tmp file to store teh archive
                     reporthook=report_hook)
         print " [Done]"

--- a/pymt/tools/packaging/win32/build.py
+++ b/pymt/tools/packaging/win32/build.py
@@ -73,7 +73,7 @@ class WindowsPortableBuild(Command):
             p = block_count*block_size*100.0/total_size
             print "\b\b\b\b\b\b\b\b\b", "%06.2f"%p +"%",
         print " Progress: 000.00%",
-        urlretrieve(self.deps_url, #location of binary dependencioes needed for portable pymt
+        urlretrieve(self.deps_url, #location of binary dependencies needed for portable pymt
                     os.path.join(self.build_dir,'deps.zip'), #tmp file to store teh archive
                     reporthook=report_hook)
         print " [Done]"

--- a/pymt/ui/widgets/circularslider.py
+++ b/pymt/ui/widgets/circularslider.py
@@ -20,7 +20,7 @@ class MTCircularSlider(MTWidget):
 
     .. warning::
         The widget is drawed from his center. Cause of that, the size of the
-        widget will be automaticly adjusted from the radius of the slider.
+        widget will be automatically adjusted from the radius of the slider.
         Eg: if you ask for a radius=100, the widget size will be 200x200
 
     :Parameters:

--- a/pymt/ui/widgets/composed/vkeyboard.py
+++ b/pymt/ui/widgets/composed/vkeyboard.py
@@ -387,7 +387,7 @@ class MTVKeyboard(MTScatterWidget):
             self._need_update = None
 
     def _do_update(self, mode=None):
-        # we absolutly want mode to update displaylist.
+        # we absolutely want mode to update displaylist.
         if mode not in ('background', 'keys'):
             return
 

--- a/pymt/ui/widgets/layout/gridlayout.py
+++ b/pymt/ui/widgets/layout/gridlayout.py
@@ -108,7 +108,7 @@ class MTGridLayout(MTAbstractLayout):
         for i in rows:
             height += rows[i]
 
-        #remeber for layout
+        #remember for layout
         self.col_widths  = cols
         self.row_heights = rows
 

--- a/pymt/ui/widgets/scatter.py
+++ b/pymt/ui/widgets/scatter.py
@@ -415,7 +415,7 @@ class MTScatter(MTWidget):
             self.transform_with_touch (touch)
             self._last_touch_pos[touch] = touch.pos
 
-        # stop porpagating if its within our bounds
+        # stop propagating if its within our bounds
         if self.collide_point(x, y):
             return True
 
@@ -436,7 +436,7 @@ class MTScatter(MTWidget):
             del self._last_touch_pos[touch]
             self._touches.remove(touch)
 
-        # stop porpagating if its within our bounds
+        # stop propagating if its within our bounds
         if self.collide_point(x, y):
             return True
 

--- a/pymt/ui/widgets/widget.py
+++ b/pymt/ui/widgets/widget.py
@@ -166,7 +166,7 @@ class MTWidget(EventDispatcher):
         self._cls = ''
         self._inline_style = kwargs['style']
 
-        # loading is done here automaticly
+        # loading is done here automatically
         self.cls = kwargs.get('cls')
 
     def _set_cls(self, cls):


### PR DESCRIPTION
There are small typos in:
- examples/apps/3Ddrawing/3Ddrawing.py
- examples/apps/mandelbrot/mandelbrot.py
- pymt/cache.py
- pymt/core/text/__init__.py
- pymt/event.py
- pymt/input/touch.py
- pymt/tools/packaging/osx/build.py
- pymt/tools/packaging/win32/build.py
- pymt/ui/widgets/circularslider.py
- pymt/ui/widgets/composed/vkeyboard.py
- pymt/ui/widgets/layout/gridlayout.py
- pymt/ui/widgets/scatter.py
- pymt/ui/widgets/widget.py

Fixes:
- Should read `automatically` rather than `automaticly`.
- Should read `propagating` rather than `porpagating`.
- Should read `dependencies` rather than `dependencioes`.
- Should read `absolutely` rather than `absolutly`.
- Should read `retrieve` rather than `retreive`.
- Should read `remember` rather than `remeber`.
- Should read `reference` rather than `refernce`.
- Should read `propagated` rather than `propogated`.
- Should read `projection` rather than `pojection`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md